### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-fuzzywuzzy = {extras = ["speedup"],version = "*"}
+rapidfuzz = "*"
 joblib = "*"
 requests = "*"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # lol_id_tools
 An id tool for League of Legends with fuzzy string matching, nicknames, multiple locales, automatic updates, and translation.
 
-The package relies on [fuzzywuzzy](https://github.com/seatgeek/fuzzywuzzy) for string matching. Nicknames are on 
+The package relies on [rapidfuzz](https://github.com/rhasspy/rapidfuzz) for string matching. Nicknames are on 
 [github](https://github.com/mrtolkien/lol_id_tools/blob/master/data/nicknames.json), please make a pull requests to 
 add new ones!
 

--- a/lol_id_tools/lol_id_tools.py
+++ b/lol_id_tools/lol_id_tools.py
@@ -6,7 +6,7 @@ from pprint import pprint
 import logging as log
 import requests
 import joblib
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 class LolIdTools:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 -i https://pypi.org/simple
 certifi==2019.11.28
 chardet==3.0.4
-fuzzywuzzy[speedup]==0.18.0
+rapidfuzz==0.2.1
 idna==2.9
 joblib==0.14.1
-python-levenshtein==0.12.0
 requests==2.23.0
 urllib3==1.25.8

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author='Tolki',
     install_requires=['requests',
                       'joblib',
-                      'fuzzywuzzy[speedup]'],
+                      'rapidfuzz'],
     author_email='gary.mialaret+pypi@gmail.com',
     description='An id tool for League of Legends with fuzzy string matching, nicknames, multiple locales, '
                 'automatic updates, and translation.',


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.

This does not update the pipfile.lock